### PR TITLE
Do not add listeners using the once function

### DIFF
--- a/lib/elasticsearch-bulk.js
+++ b/lib/elasticsearch-bulk.js
@@ -153,8 +153,8 @@ var onProcessExit = function() {
 function setupProcessListeners() {
   if (!processListenersSetup) {
     processListenersSetup = true;
-    process.once('SIGINT', onProcessSigint);
-    process.once('exit', onProcessExit);    
+    process.addListener('SIGINT', onProcessSigint);
+    process.addListener('exit', onProcessExit);    
   }
 }
 function clearProcessListeners() {


### PR DESCRIPTION
SIGINT results an assertion error because it tries to remove a listener which does not exist, since once removes the listener after the signal occurred. Using addListener fixes the issue.
