### PR TITLE
Update log4js-elasticsearch-layouts.js

### DIFF
--- a/lib/log4js-elasticsearch-layouts.js
+++ b/lib/log4js-elasticsearch-layouts.js
@@ -43,7 +43,7 @@ function simpleJsonLayout(loggingEvent) {
  */
 function logstashLayout(loggingEvent) {
   var data, fields, message, errorMsg, stack;
-  if (loggingEvent.data[0]['@fields']) {
+  if (loggingEvent.data[0] && loggingEvent.data[0]['@fields']) {
     fields = loggingEvent.data[0]['@fields'];
     message = loggingEvent.data[0]['@message'] || loggingEvent.data.toString();
   } else {


### PR DESCRIPTION
try to avoid `TypeError: Cannot read property '@fields' of undefined`
when calling `logger.error();` without parameters
